### PR TITLE
Fixes a typo which causes issues (apparently only with node 0.12?)

### DIFF
--- a/watch.js
+++ b/watch.js
@@ -169,7 +169,7 @@ var WatcherMethods = {
 
       //i need to know what fd is the active fd inter the file path
       self._fileStat = cur;
-      if(!cur.ino && pre.ino || cur.nlink === 0) {
+      if(!cur.ino && prev.ino || cur.nlink === 0) {
         //no hardlinks left to this file. 
         //or no inode. its unlinked for sure.
         self.emit('unlink',self.fds[cur.ino].fd,self.fds[cur.ino].getData());


### PR DESCRIPTION
This fixes a typo which apparently went unnoticed for quite a while. I have been using your library for about a year now and never encountered this problem until a recent update to node 0.12.

Anyway, this should be straight-forward to accept, so I haven't put more effort into the investigation. Would be great to see an updated version (and tailfd) soon.

Thanks!
